### PR TITLE
Add 'Add Variable by Name' to the right click menu, allow execute commands from the command palette

### DIFF
--- a/package.json
+++ b/package.json
@@ -165,17 +165,17 @@
           "group": "0_default@3"
         },
         {
-          "command": "vaporview.addAllInModuleShallow",
+          "command": "vaporview.addAllInScopeShallow",
           "when": "viewItem == 'netlistScope'",
           "group": "0_default@4"
         },
         {
-          "command": "vaporview.addAllInModuleRecursive",
+          "command": "vaporview.addAllInScopeRecursive",
           "when": "viewItem == 'netlistScope'",
           "group": "0_default@5"
         },
         {
-          "command": "vaporview.removeAllInModule",
+          "command": "vaporview.removeAllInScope",
           "when": "viewItem == 'netlistScope'",
           "group": "0_default@6"
         },
@@ -186,22 +186,26 @@
         },
         {
           "command": "vaporview.copyName",
-          "group": "0_default@7"
+          "group": "0_default@8"
+        },
+        {
+          "command": "vaporview.addVariableByInstancePath",
+          "group": "1_addVariable"
         },
         {
           "command": "vaporview.saveViewerSettings",
           "when": "view == 'netlistContainer' || view == 'displaylistContainer'",
-          "group": "1_saveLoad@1"
+          "group": "2_saveLoad@1"
         },
         {
           "command": "vaporview.loadViewerSettings",
           "when": "view == 'netlistContainer' || view == 'displaylistContainer'",
-          "group": "1_saveLoad@2"
+          "group": "2_saveLoad@2"
         },
         {
           "command": "vaporview.reloadFile",
           "when": "view == 'netlistContainer' || view == 'displaylistContainer'",
-          "group": "2_reload"
+          "group": "3_reload"
         }
       ],
       "webview/context": [
@@ -386,14 +390,14 @@
       },
       {
         "command": "vaporview.addVariableByInstancePath",
-        "title": "Add To Vaporview"
+        "title": "Add Variable by Name"
       },
       {
-        "command": "vaporview.addAllInModuleShallow",
+        "command": "vaporview.addAllInScopeShallow",
         "title": "Add All Variables in Scope (Shallow)"
       },
       {
-        "command": "vaporview.addAllInModuleRecursive",
+        "command": "vaporview.addAllInScopeRecursive",
         "title": "Add All Variables in Scope (Recursive)"
       },
       {
@@ -405,7 +409,7 @@
         "title": "Remove Selected"
       },
       {
-        "command": "vaporview.removeAllInModule",
+        "command": "vaporview.removeAllInScope",
         "title": "Remove All Variables in Scope"
       },
       {

--- a/src/extension_core/extension.ts
+++ b/src/extension_core/extension.ts
@@ -48,7 +48,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
   // Add or remove signal commands
   context.subscriptions.push(vscode.commands.registerCommand('vaporview.addVariableByInstancePath', (e) => {
-    viewerProvider.addSignalByNameToDocument(e.instancePath);
+    viewerProvider.addVariableByInstancePathToDocument(e);
   }));
 
   context.subscriptions.push(vscode.commands.registerCommand('vaporview.removeSignal', (e) => {
@@ -61,14 +61,12 @@ export async function activate(context: vscode.ExtensionContext) {
     viewerProvider.filterAddSignalsInNetlist(viewerProvider.netlistViewSelectedSignals, false);
   }));
 
-  context.subscriptions.push(vscode.commands.registerCommand('vaporview.addAllInModuleShallow', (e) => {
-    if (e.collapsibleState === vscode.TreeItemCollapsibleState.None) {return;}
-    viewerProvider.addChildVariablesToDocument(e, false, 128);
+  context.subscriptions.push(vscode.commands.registerCommand('vaporview.addAllInScopeShallow', (e) => {
+    viewerProvider.addAllInScopeToDocument(e, false, 128);
   }));
 
-  context.subscriptions.push(vscode.commands.registerCommand('vaporview.addAllInModuleRecursive', (e) => {
-    if (e.collapsibleState === vscode.TreeItemCollapsibleState.None) {return;}
-    viewerProvider.addChildVariablesToDocument(e, true, 128);
+  context.subscriptions.push(vscode.commands.registerCommand('vaporview.addAllInScopeRecursive', (e) => {
+    viewerProvider.addAllInScopeToDocument(e, true, 128);
   }));
 
   context.subscriptions.push(vscode.commands.registerCommand('vaporview.removeSelectedNetlist', (e) => {
@@ -79,7 +77,7 @@ export async function activate(context: vscode.ExtensionContext) {
     viewerProvider.removeSelectedSignalsFromDocument('displayedSignals');
   }));
 
-  context.subscriptions.push(vscode.commands.registerCommand('vaporview.removeAllInModule', (e) => {
+  context.subscriptions.push(vscode.commands.registerCommand('vaporview.removeAllInScope', (e) => {
     if (e.collapsibleState === vscode.TreeItemCollapsibleState.None) {return;}
     viewerProvider.removeSignalList(e.children);
   }));

--- a/src/extension_core/viewer_provider.ts
+++ b/src/extension_core/viewer_provider.ts
@@ -553,7 +553,8 @@ export class WaveformViewerProvider implements vscode.CustomReadonlyEditorProvid
     const metadata = await document.findTreeItem(lookup, msb, lsb);
 
     if (metadata === null) {
-      console.log('Signal not found ' + signalName);
+      // console.log('Signal not found ' + signalName);
+      vscode.window.showWarningMessage('Signal not found: ' + signalName);
       return;
     }
 
@@ -571,6 +572,48 @@ export class WaveformViewerProvider implements vscode.CustomReadonlyEditorProvid
     } else {
       this.addSignalsToDocument([metadata]);
     }
+  }
+
+  public async addVariableByInstancePathToDocument(e: any) {
+    if (e === undefined || e.instancePath === undefined) { // Executed from the command palette
+      vscode.window.showInputBox({
+        prompt: 'Enter variable name',
+        placeHolder: 'top.mid.var'
+      }).then(userInput => {
+        if (userInput !== undefined && userInput !== '') {
+          this.addSignalByNameToDocument(`${userInput}`);
+        }
+      });
+      return;
+    }
+    this.addSignalByNameToDocument(e.instancePath);
+  }
+
+  public async addAllInScopeToDocument(e: NetlistItem, recursive: boolean, maxChildren: number) {
+    if (e === undefined) { // Executed from the command palette
+      vscode.window.showInputBox({
+        prompt: 'Enter scope name',
+        placeHolder: 'top.mid.scope'
+      }).then(userInput => {
+        if (userInput !== undefined && userInput !== '') {
+          this.addChildVariablesToDocumentByName(`${userInput}`, recursive, maxChildren);
+        }
+      });
+      return;
+    }
+    if (e.collapsibleState === vscode.TreeItemCollapsibleState.None) {return;}
+    this.addChildVariablesToDocument(e, recursive, maxChildren);
+  }
+
+  public async addChildVariablesToDocumentByName(name: string, recursive: boolean, maxChildren: number) {
+    if (!this.activeDocument) {return;}
+    const document = this.activeDocument;
+    const netlistItem = await document.findTreeItem(name, undefined, undefined);
+    if (netlistItem === null || netlistItem.contextValue !== 'netlistScope') {
+      vscode.window.showWarningMessage('Scope not found: ' + name);
+      return;
+    }
+    this.addChildVariablesToDocument(netlistItem, recursive, maxChildren);
   }
 
   public async addChildVariablesToDocument(netlistItem: NetlistItem, recursive: boolean, maxChildren: number) {


### PR DESCRIPTION
1. Add 'Add Variable by Name' to the right click menu -> user can input full name to add variable
 
The equivalence in Verdi is 'Add signal by name'. This does not affect terminal link.

![image](https://github.com/user-attachments/assets/641ab21f-cb4b-47ed-9104-4110d4ae750d)


2. Allow execute commands from the command palette (take user input): 
 - 'Add Variable by Name'
 - 'Add All Variables in Scope (Shallow)'
 - 'Add All Variables in Scope (Recursive)'

No change if executed from tree item.

![image](https://github.com/user-attachments/assets/5e19fca8-537b-43a2-9e07-bf48bb6ddbb6)

![image](https://github.com/user-attachments/assets/236672e2-d585-4c57-a121-8243d775f2de)

