### PR TITLE
Expose marker set event for inter-extension communication

### DIFF
--- a/src/extension_core/extension.ts
+++ b/src/extension_core/extension.ts
@@ -330,6 +330,11 @@ export async function activate(context: vscode.ExtensionContext) {
     viewerProvider.log.appendLine("Command called: 'vaporview.dummy' " + JSON.stringify(e));
   }
   ));
+
+  const markerSetEvent = WaveformViewerProvider.markerSetEvent;
+  return {
+    markerSetEvent
+  };
 }
 
 export default WaveformViewerProvider;

--- a/src/extension_core/viewer_provider.ts
+++ b/src/extension_core/viewer_provider.ts
@@ -43,6 +43,11 @@ export function logScaleFromUnits(unit: string | undefined) {
   }
 }
 
+export interface markerSetEventData {
+  filePath: string;
+  time: number;
+}
+
 // #region WaveformViewerProvider
 export class WaveformViewerProvider implements vscode.CustomReadonlyEditorProvider<VaporviewDocument> {
 
@@ -73,6 +78,8 @@ export class WaveformViewerProvider implements vscode.CustomReadonlyEditorProvid
   public displayedSignalsViewSelectedSignals: NetlistItem[] = [];
   public log: vscode.OutputChannel;
   public get numDocuments(): number {return this.numDocuments;}
+
+  public static readonly markerSetEvent = new vscode.EventEmitter<markerSetEventData>();
 
   constructor(
     private readonly _context: vscode.ExtensionContext, 
@@ -187,7 +194,7 @@ export class WaveformViewerProvider implements vscode.CustomReadonlyEditorProvid
         case 'close-webview':       {webviewPanel.dispose(); break;}
         case 'setTime':             {this.updateStatusBarItems(document, e); break;}
         case 'setSelectedSignal':   {this.updateStatusBarItems(document, e); break;}
-        case 'contextUpdate' :      {this.updateStatusBarItems(document, e); break;}
+        case 'contextUpdate':       {this.updateStatusBarItems(document, e); WaveformViewerProvider.markerSetEvent.fire({ filePath: document.uri.fsPath, time: e.markerTime }); break;}
         case 'fetchTransitionData': {document.getSignalData(e.signalIdList); break;}
         case 'removeVariable':      {this.removeSignalFromDocument(e.netlistId); break;}
         case 'restoreState':        {this.applySettings(e.state, this.getDocumentFromUri(e.uri.toString())); break;}


### PR DESCRIPTION
Add 'markerSetEvent' to the exported API in 'activate' function

In this way, other extensions can listen to marker set events with following snippet, and get new values at time upon them
```node.js
async listenToMarkerSetEventEvent(): Promise<vscode.Disposable | undefined> {
    // Get the extension by its ID
    const waveformViewer = vscode.extensions.getExtension('lramseyer.vaporview');
    if (waveformViewer) {
        // Ensure the extension is active
        if (!waveformViewer.isActive) {
            await waveformViewer.activate();
        }
        // Access the exported API
        const api = waveformViewer.exports;
        // Verify the API and event exist
        if (api && api.markerSetEvent) {
            // Subscribe to the event and return the Disposable
            const disposable = api.markerSetEvent.event((data: any) => {
                console.log('Event received:', data);
            });
            return disposable;
        }
    }
    // Return undefined if the extension or event is unavailable
    return undefined;
}
```