### PR TITLE
Update netlist search to include scope path parameter

### DIFF
--- a/src/extension_core/document.ts
+++ b/src/extension_core/document.ts
@@ -39,7 +39,7 @@ export interface WaveformFileParser {
   getSignalData(signalIdList: SignalId[]): Promise<void>;
   getEnumData(enumList: EnumQueueEntry[]): Promise<void>;
   getValuesAtTime(time: number, instancePaths: string[]): Promise<any>;
-  searchNetlist(searchString: string): Promise<NetlistSearchResult>
+  searchNetlist(scopePath: string, searchString: string): Promise<NetlistSearchResult>
 
   // Callbacks
   postMessageToWebview(message: any): void;
@@ -695,8 +695,8 @@ export class VaporviewDocument extends vscode.Disposable implements vscode.Custo
     return this._handler.getValuesAtTime(time, e.instancePaths);
   }
 
-  public searchNetlist(searchQuery: string): Promise<NetlistSearchResult> {
-    return this._handler.searchNetlist(searchQuery);
+  public searchNetlist(scopePath: string, searchQuery: string): Promise<NetlistSearchResult> {
+    return this._handler.searchNetlist(scopePath, searchQuery);
   }
 
   public async unload(): Promise<void> {
@@ -743,23 +743,64 @@ export class NetlistSearchQuickPick {
   private document: VaporviewDocument | undefined;
   private searchInProgress = false;
   private pendingQuery: string | undefined;
+  private scopeHistory: string[] = []; // stack of full scope paths
+  private expectedHide = false; // whether hide the quickPick, will be true only when selected a var
 
   constructor() {
     this.quickPick = vscode.window.createQuickPick<NetlistQuickPickItem>();
-    this.quickPick.placeholder = 'Search netlist by instance path...';
     this.quickPick.matchOnDetail = true;
     this.quickPick.busy = false;
-    this.quickPick.onDidHide(() => {this.quickPick.value = "";});
+    
+    this.quickPick.onDidHide(() => {
+      if (this.scopeHistory.length > 0 && !this.expectedHide) {
+        // go back to previous search scope instead of closing
+        this.scopeHistory.pop();
+        this.restoreScope();
+        this.quickPick.show();
+      } else {
+        this.expectedHide = false;
+        this.quickPick.value = "";
+        this.scopeHistory = [];
+        this.quickPick.step = undefined;
+        this.quickPick.buttons = [];
+      }
+    });
 
     this.quickPick.onDidChangeValue((value) => this.applyFilter(value));
     this.quickPick.onDidAccept(() => this.onAccept());
+    this.quickPick.onDidTriggerButton((button) => {
+      if (button === vscode.QuickInputButtons.Back && this.scopeHistory.length > 0) {
+        this.scopeHistory.pop();
+        this.restoreScope();
+      }
+    });
   }
 
   public show(document: VaporviewDocument) {
     this.document = document;
     this.pendingQuery = undefined;
     this.searchInProgress = false;
+    this.scopeHistory = [];
+    this.quickPick.buttons = [];
+    this.quickPick.placeholder = 'Search netlist by instance path...';
+    this.quickPick.value = "";
+    this.quickPick.items = [];
+    this.quickPick.title = undefined;
     this.quickPick.show();
+  }
+  // update the search info, update the search scope to the last scope of history
+  private restoreScope() {
+    if (this.scopeHistory.length > 0) {
+      const scope = this.scopeHistory[this.scopeHistory.length - 1];
+      this.quickPick.buttons = [vscode.QuickInputButtons.Back];
+      this.quickPick.placeholder = `Search within ${scope}...`;
+    } else {
+      this.quickPick.buttons = [];
+      this.quickPick.placeholder = 'Search netlist by instance path...';
+    }
+    this.quickPick.value = "";
+    this.quickPick.items = [];
+    this.quickPick.title = undefined;
   }
 
   private async applyFilter(query: string) {
@@ -778,29 +819,34 @@ export class NetlistSearchQuickPick {
 
     this.searchInProgress  = true;
     this.quickPick.busy    = true;
-    const searchResult     = await this.document.searchNetlist(query);
+    const scopePrefix      = this.scopeHistory.length > 0 ? this.scopeHistory[this.scopeHistory.length - 1] : "";
+    const searchResult     = await this.document.searchNetlist(scopePrefix, query);
     this.searchInProgress  = false;
 
     const totalResults     = searchResult.totalResults;
     const displayedResults = searchResult.searchResults.length;
     const resultString     = totalResults === 1 ? "result" : "results";
 
+    const scopeString = scopePrefix ? `in ${scopePrefix}` : "";
     if (totalResults === 0) {
-      this.quickPick.title = "No results found";
+      this.quickPick.title = `No results found ${scopeString}`;
     } else if (displayedResults !== totalResults) {
-      this.quickPick.title = `Showing ${displayedResults} of ${totalResults} ${resultString}`;
+      this.quickPick.title = `Showing ${displayedResults} of ${totalResults} ${resultString} ${scopeString}`;
     } else {
-      this.quickPick.title = `${totalResults} ${resultString}`;
+      this.quickPick.title = `${totalResults} ${resultString} ${scopeString}`;
     }
 
     this.quickPick.items = searchResult.searchResults.map(result => {
       const icon       = result.isVar ? getVarIcon(result.type) : getScopeIcon(result.type);
       const bitRange   = result.isVar ? bitRangeString(result.msb, result.lsb) : "";
       const paramValue = result.paramValue ? ": " + parseParamValue(result.paramValue) : "";
+      const relativePath = scopePrefix && result.instancePath.startsWith(scopePrefix + '.')
+        ? result.instancePath.slice(scopePrefix.length + 1)
+        : result.instancePath;
       return {
         label: result.instancePath.slice(result.instancePath.lastIndexOf(".") + 1) + bitRange,
         description: result.type + paramValue,
-        detail: result.instancePath,
+        detail: relativePath,
         instancePath: result.instancePath,
         isVar: result.isVar,
         msb: result.msb || 0,
@@ -827,9 +873,11 @@ export class NetlistSearchQuickPick {
     if (selected.isVar) {
       const metadata = await this.document.findTreeItem(selected.instancePath, selected.msb, selected.lsb);
       if (metadata) {this.document.renderSignals([metadata.netlistId], [], undefined);}
+      this.expectedHide = true;
       this.quickPick.hide();
     } else {
-      this.quickPick.value = selected.instancePath + ".";
+      this.scopeHistory.push(selected.instancePath);
+      this.restoreScope();
     }
   }
 }

--- a/src/extension_core/document.ts
+++ b/src/extension_core/document.ts
@@ -827,13 +827,13 @@ export class NetlistSearchQuickPick {
     const displayedResults = searchResult.searchResults.length;
     const resultString     = totalResults === 1 ? "result" : "results";
 
-    const scopeString = scopePrefix ? `in ${scopePrefix}` : "";
+    const scopeString = scopePrefix ? ` in ${scopePrefix}` : "";
     if (totalResults === 0) {
-      this.quickPick.title = `No results found ${scopeString}`;
+      this.quickPick.title = `No results found${scopeString}`;
     } else if (displayedResults !== totalResults) {
-      this.quickPick.title = `Showing ${displayedResults} of ${totalResults} ${resultString} ${scopeString}`;
+      this.quickPick.title = `Showing ${displayedResults} of ${totalResults} ${resultString}${scopeString}`;
     } else {
-      this.quickPick.title = `${totalResults} ${resultString} ${scopeString}`;
+      this.quickPick.title = `${totalResults} ${resultString}${scopeString}`;
     }
 
     this.quickPick.items = searchResult.searchResults.map(result => {

--- a/src/extension_core/fsdb_handler.ts
+++ b/src/extension_core/fsdb_handler.ts
@@ -361,7 +361,7 @@ export class FsdbFormatHandler implements WaveformFileParser {
   }
 
   // TODO: @heyfey - implement netlist search
-  public searchNetlist(searchString: string): Promise<NetlistSearchResult> {
+  public searchNetlist(scopePath: string, searchString: string): Promise<NetlistSearchResult> {
     return Promise.resolve({totalResults: 0, searchResults: []});
   }
 }

--- a/src/extension_core/surfer_handler.ts
+++ b/src/extension_core/surfer_handler.ts
@@ -323,8 +323,8 @@ export class SurferFormatHandler implements WaveformFileParser {
     }
   }
 
-  public async searchNetlist(searchString: string): Promise<NetlistSearchResult> {
-    const resultJson = await this.wasmApi.searchnetlist(searchString);
+  public async searchNetlist(scopePath: string, searchString: string): Promise<NetlistSearchResult> {
+    const resultJson = await this.wasmApi.searchnetlist(scopePath, searchString);
     try {
       return JSON.parse(resultJson) as NetlistSearchResult;
     } catch {

--- a/src/extension_core/wasm_handler.ts
+++ b/src/extension_core/wasm_handler.ts
@@ -369,8 +369,8 @@ export class WasmFormatHandler implements WaveformFileParser {
     return JSON.parse(result);
   }
 
-  public async searchNetlist(searchString: string): Promise<NetlistSearchResult> {
-    const resultJson = await this.wasmApi.searchnetlist(searchString);
+  public async searchNetlist(scopePath: string, searchString: string): Promise<NetlistSearchResult> {
+    const resultJson = await this.wasmApi.searchnetlist(scopePath, searchString);
     try {
       return JSON.parse(resultJson) as NetlistSearchResult;
     } catch {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+use std::collections::VecDeque;
+
 // Use a procedural macro to generate bindings for the world we specified in
 // `host.wit`
 
@@ -422,49 +424,54 @@ fn scope_search_entry(scope_data: &Scope, hierarchy: &Hierarchy) -> SearchEntry 
   };
 }
 
+/// Breadth-first search all descendants of a scope for items matching `search_string`.
+/// If `scope` is None, searches all top-level scopes and vars.
 fn search<'h>(
   hierarchy: &'h Hierarchy,
-  scope_path: Vec<&str>,
-  iter_scopes: impl Iterator<Item = &'h Scope>,
-  iter_vars: Option<impl Iterator<Item = &'h Var>>,
+  scope: Option<&'h Scope>,
+  search_string: &str,
   search_results: &mut Vec<ScopeOrVar<'h>>,
 ) {
+  // Seed the queue with either the single scope or all top-level scopes
+  let mut queue: VecDeque<&Scope> = if let Some(s) = scope {
+    VecDeque::from([s])
+  } else {
+    hierarchy.iter_scopes().collect()
+  };
 
-  if scope_path.is_empty() { return; }
-  let search_string = scope_path[0].to_string();
-  let new_scope_path = scope_path[1..].to_vec();
-  let search_depth = new_scope_path.len();
-
-  for scope_data in iter_scopes {
-    let name = scope_data.name(hierarchy).to_string().to_lowercase();
-    if name.contains(&search_string) {
-      if search_depth == 0 {
-        search_results.push(ScopeOrVar::Scope(scope_data));
-      } else {
-        // Collect children before recursing to avoid overlapping borrows
-        let search_scope_path = new_scope_path.clone();
-        let child_scopes: Vec<&'h Scope> = scope_data.scopes(hierarchy)
-          .map(|scope_ref| hierarchy.index(scope_ref))
-          .collect();
-        let mut child_vars: Option<Vec<&'h Var>> = None;
-        if search_depth == 1 {
-          let var_iter: Vec<&'h Var> = scope_data.vars(hierarchy)
-            .map(|var_ref| hierarchy.index(var_ref))
-            .collect();
-          child_vars = Some(var_iter);
-        }
-        search(hierarchy, search_scope_path, child_scopes.into_iter(), child_vars.map(|v| v.into_iter()), search_results);
+  // For top-level search, also search top-level vars first
+  if scope.is_none() {
+    for var_data in hierarchy.iter_vars() {
+      let name = var_data.name(hierarchy).to_string().to_lowercase();
+      if name.contains(search_string) {
+        search_results.push(ScopeOrVar::Var(var_data));
       }
     }
   }
 
-  if search_depth > 0 { return; }
-  if let Some(iter_vars) = iter_vars {
-    for var_data in iter_vars {
-      let name = var_data.name(hierarchy).to_string().to_lowercase();
-      if name.contains(&search_string) {
-        search_results.push(ScopeOrVar::Var(var_data));
+  while let Some(current) = queue.pop_front() {
+    let name = current.name(hierarchy).to_string().to_lowercase();
+    if scope.is_none() && name.contains(search_string) {
+      search_results.push(ScopeOrVar::Scope(current));
+    }
+
+    // Search vars in this scope
+    for var_ref in current.vars(hierarchy) {
+      let var = hierarchy.index(var_ref);
+      let name = var.name(hierarchy).to_string().to_lowercase();
+      if name.contains(search_string) {
+        search_results.push(ScopeOrVar::Var(var));
       }
+    }
+
+    // Enqueue child scopes for the next level
+    for scope_ref in current.scopes(hierarchy) {
+      let child = hierarchy.index(scope_ref);
+      let name = child.name(hierarchy).to_string().to_lowercase();
+      if name.contains(search_string) {
+        search_results.push(ScopeOrVar::Scope(child));
+      }
+      queue.push_back(child);
     }
   }
 }
@@ -922,7 +929,7 @@ impl Guest for Filecontext {
 
   }
 
-  fn searchnetlist(searchquery: String) -> String {
+  fn searchnetlist(scopepath: String, searchquery: String) -> String {
     let global_hierarchy = _hierarchy.lock().unwrap();
     let hierarchy = global_hierarchy.as_ref().unwrap();
     let empty_result = "{\"totalResults\":0,\"searchResults\":[]}".to_string();
@@ -931,17 +938,40 @@ impl Guest for Filecontext {
       return empty_result;
     }
 
-    let mut search_results: Vec<ScopeOrVar> = Vec::new();
     let lower_query = searchquery.to_lowercase();
-    let scope_path = lower_query.split(".").collect::<Vec<&str>>();
 
-    let all_scopes = hierarchy.iter_scopes();
-    let mut all_vars = None;
-    if scope_path.len() == 1 {
-      all_vars = Some(hierarchy.iter_vars());
-    }
+    // Navigate to target scope if scopepath is provided
+    let target_scope = if scopepath.is_empty() {
+      None
+    } else {
+      let lower_path = scopepath.to_lowercase();
+      let path_segments: Vec<&str> = lower_path.split(".").collect();
 
-    search(hierarchy, scope_path, all_scopes, all_vars, &mut search_results);
+      let mut current_scopes: Vec<&Scope> = hierarchy.iter_scopes()
+        .filter(|s| s.name(hierarchy).to_string().to_lowercase() == path_segments[0])
+        .collect();
+
+      for segment in path_segments.iter().skip(1) {
+        let mut next_scopes = Vec::new();
+        for scope in &current_scopes {
+          for child_ref in scope.scopes(hierarchy) {
+            let child = hierarchy.index(child_ref);
+            if child.name(hierarchy).to_string().to_lowercase() == *segment {
+              next_scopes.push(child);
+            }
+          }
+        }
+        current_scopes = next_scopes;
+        if current_scopes.is_empty() {
+          return empty_result;
+        }
+      }
+
+      current_scopes.first().copied()
+    };
+
+    let mut search_results: Vec<ScopeOrVar> = Vec::new();
+    search(hierarchy, target_scope, &lower_query, &mut search_results);
 
     let total = search_results.len();
     let return_amount = std::cmp::min(total, 100);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -436,15 +436,18 @@ fn search<'h>(
   let mut queue: VecDeque<&Scope> = if let Some(s) = scope {
     VecDeque::from([s])
   } else {
-    hierarchy.iter_scopes().collect()
+    let mut q: VecDeque<&Scope> = VecDeque::new();
+    for s in hierarchy.iter_scopes() {
+      let name = s.name(hierarchy).to_string().to_lowercase();
+      if name.contains(search_string) {
+        search_results.push(ScopeOrVar::Scope(s));
+      }
+      q.push_back(s);
+    }
+    q
   };
 
   while let Some(current) = queue.pop_front() {
-    let name = current.name(hierarchy).to_string().to_lowercase();
-    if scope.is_none() && name.contains(search_string) {
-      search_results.push(ScopeOrVar::Scope(current));
-    }
-
     // Search vars in this scope
     for var_ref in current.vars(hierarchy) {
       let var = hierarchy.index(var_ref);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -437,7 +437,8 @@ fn search<'h>(
     VecDeque::from([s])
   } else {
     let mut q: VecDeque<&Scope> = VecDeque::new();
-    for s in hierarchy.iter_scopes() {
+    for scope_ref in hierarchy.scopes() {
+      let s = hierarchy.index(scope_ref);
       let name = s.name(hierarchy).to_string().to_lowercase();
       if name.contains(search_string) {
         search_results.push(ScopeOrVar::Scope(s));
@@ -940,7 +941,8 @@ impl Guest for Filecontext {
       let lower_path = scopepath.to_lowercase();
       let path_segments: Vec<&str> = lower_path.split(".").collect();
 
-      let mut current_scopes: Vec<&Scope> = hierarchy.iter_scopes()
+      let mut current_scopes: Vec<&Scope> = hierarchy.scopes()
+        .map(|sr| hierarchy.index(sr))
         .filter(|s| s.name(hierarchy).to_string().to_lowercase() == path_segments[0])
         .collect();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -439,16 +439,6 @@ fn search<'h>(
     hierarchy.iter_scopes().collect()
   };
 
-  // For top-level search, also search top-level vars first
-  if scope.is_none() {
-    for var_data in hierarchy.iter_vars() {
-      let name = var_data.name(hierarchy).to_string().to_lowercase();
-      if name.contains(search_string) {
-        search_results.push(ScopeOrVar::Var(var_data));
-      }
-    }
-  }
-
   while let Some(current) = queue.pop_front() {
     let name = current.name(hierarchy).to_string().to_lowercase();
     if scope.is_none() && name.contains(search_string) {

--- a/wit/filehandler.wit
+++ b/wit/filehandler.wit
@@ -37,7 +37,7 @@ world filehandler {
   export getsignaldata: func(signalidlist: list<u32>);
   export getenumdata: func(netlistidlist: list<u32>);
   export getvaluesattime: func(time: u64, paths: string) -> string;
-  export searchnetlist: func(searchquery: string) -> string;
+  export searchnetlist: func(scopepath: string, searchquery: string) -> string;
 
   export loadremotestatus: func(status: list<u8>) -> string;
   export loadremotechunk: func(chunk-type: u32, chunk-data: list<u8>, chunk-index: u32, total-chunks: u32);


### PR DESCRIPTION
As mentioned in #177, Modify the search logic:

+ When the search target is set to module, a new search box will be opened to perform further searches under the selected module until a signal is selected.

+ The search results are modified to display all signals/modules (default: global scope) that contain the search string within the current module. The search is performed using a breadth‑first approach.

+ Shorten the path displayed in search results by removing the prefix of the module where the search occurred.

<img width="733" height="517" alt="image" src="https://github.com/user-attachments/assets/b3a1bcf7-066a-462f-94bc-c239457ee4be" />


**Note: I am not a Rust programmer. The Rust code was written with the assistance of AI. I have reviewed the code to the best of my ability, a double‑check would be appreciated.**

Any feedback or ideas regarding the search logic or related areas are welcome.