### PR TITLE
Natural sort of elements in netlist

### DIFF
--- a/src/extension_core/document.ts
+++ b/src/extension_core/document.ts
@@ -522,9 +522,9 @@ export class VaporviewDocument extends vscode.Disposable implements vscode.Custo
     const signals = variables.filter(item => item.type !== 'Parameter');
 
     if (this.sortNetlist) {
-      result.push(...(scopes.sort((a, b) => a.name.localeCompare(b.name))));
-      result.push(...(parameters.sort((a, b) => a.name.localeCompare(b.name))));
-      result.push(...(signals.sort((a, b) => a.name.localeCompare(b.name))));
+      result.push(...(scopes.sort((a, b) => a.name.localeCompare(b.name, undefined, {numeric: true}))));
+      result.push(...(parameters.sort((a, b) => a.name.localeCompare(b.name, undefined, {numeric: true}))));
+      result.push(...(signals.sort((a, b) => a.name.localeCompare(b.name, undefined, {numeric: true}))));
     } else {
       result.push(...scopes);
       result.push(...parameters);


### PR DESCRIPTION
The sorting of items in the netlist has been changed from alphabetical to natural.
Before:
<img width="136" height="268" alt="изображение" src="https://github.com/user-attachments/assets/b0fc0d49-c6a0-4f56-bc17-be6a48133535" />
After:
<img width="145" height="355" alt="изображение" src="https://github.com/user-attachments/assets/247853a8-3450-4a83-b274-502f90fc96b1" />

