### PR TITLE
Load FSDB scopes lazily and nest struct fields

### DIFF
--- a/src/extension_core/document.ts
+++ b/src/extension_core/document.ts
@@ -176,7 +176,7 @@ export class VaporviewDocument extends vscode.Disposable implements vscode.Custo
     const loadTime    = Date.now();
     await this._handler.loadNetlist();
     const netlistTime = (Date.now() - loadTime) / 1000;
-    this.treeData     = await this._handler.getChildren(undefined);
+    this.treeData     = await this.getScopeChildren(undefined);
     this._providerDelegate.updateViews(this.uri);
     this.setSearchCommandContext();
 

--- a/src/extension_core/fsdb_handler.ts
+++ b/src/extension_core/fsdb_handler.ts
@@ -7,7 +7,7 @@ import type { VaporviewDocumentDelegate } from './viewer_provider';
 import { type NetlistItem, createScope, createVar } from './tree_view';
 import type { WaveformFileParser, NetlistSearchResult, NetlistSearchEntry } from './document';
 import type { ValuesAtTimeResult } from '../../packages/vaporview-api/types';
-import type { FsdbWaveformData, FsdbWorkerCommand } from './fsdb_types';
+import type { FsdbScopeChildrenResult, FsdbScopeInfo, FsdbWaveformData, FsdbWorkerCommand } from './fsdb_types';
 
 // Response to a callFsdbWorkerTask request (matched by id)
 type FsdbWorkerResponse = {
@@ -20,19 +20,6 @@ type FsdbWorkerResponse = {
 type FsdbRequireFailedMessage = {
   command: 'require-failed';
   error: { code?: string };
-};
-
-type FsdbScopeCallbackMessage = {
-  command: 'fsdb-scope-callback';
-  name: string;
-  type: string;
-  path: string;
-  netlistId: number;
-  scopeOffsetIdx: number;
-};
-
-type FsdbUpscopeCallbackMessage = {
-  command: 'fsdb-upscope-callback';
 };
 
 type FsdbSetMetadataMessage = {
@@ -75,15 +62,27 @@ type FsdbArrayEndCallbackMessage = {
   size: number;
 };
 
+type FsdbStructBeginCallbackMessage = {
+  command: 'fsdb-struct-begin-callback';
+  name: string;
+  type: string;
+  path: string;
+  netlistId: number;
+};
+
+type FsdbStructEndCallbackMessage = {
+  command: 'fsdb-struct-end-callback';
+};
+
 type FsdbWorkerCallback =
   | FsdbRequireFailedMessage
-  | FsdbScopeCallbackMessage
-  | FsdbUpscopeCallbackMessage
   | FsdbSetMetadataMessage
   | FsdbSetChunkSizeMessage
   | FsdbVarCallbackMessage
   | FsdbArrayBeginCallbackMessage
-  | FsdbArrayEndCallbackMessage;
+  | FsdbArrayEndCallbackMessage
+  | FsdbStructBeginCallbackMessage
+  | FsdbStructEndCallbackMessage;
 
 type FsdbWorkerMessage = FsdbWorkerResponse | FsdbWorkerCallback;
 
@@ -92,8 +91,12 @@ export class FsdbFormatHandler implements WaveformFileParser {
   private providerDelegate: VaporviewDocumentDelegate;
   private uri: vscode.Uri;
   private fsdbWorker: ChildProcess | undefined = undefined;
-  private fsdbTopModuleCount: number = 0;
   private fsdbCurrentScope: NetlistItem | undefined = undefined;
+  // Vars collected for the in-flight readVars call (avoids races on children.push).
+  private fsdbVarsBuffer: NetlistItem[] = [];
+  // Nest STRUCT/RECORD/array children while reading vars for a scope.
+  private fsdbChildrenStack: NetlistItem[][] = [];
+  private fsdbStructNameStack: string[] = [];
   // Need a reference to findTreeItem for getValuesAtTime
   public findTreeItemFn: (scopePath: string, msb: number | undefined, lsb: number | undefined) => Promise<NetlistItem | null>;
 
@@ -101,6 +104,8 @@ export class FsdbFormatHandler implements WaveformFileParser {
   public netlistSearchable: boolean = false;
   private netlistTop: NetlistItem[] = [];
   private parametersLoaded: boolean = false;
+  // VS Code may call getChildren concurrently while expanding; coalesce loads.
+  private childrenLoadInFlight = new Map<NetlistItem, Promise<NetlistItem[]>>();
 
   public postMessageToWebview = (_message: Record<string, unknown>) => {};
   public metadata: WaveformDumpMetadata = {
@@ -152,9 +157,13 @@ export class FsdbFormatHandler implements WaveformFileParser {
       title: "Reading Scopes for " + this.uri.fsPath,
       cancellable: false
     }, async () => {
-      await this.callFsdbWorkerTask({
+      const response = await this.callFsdbWorkerTask({
         command: 'readScopes'
       });
+      const topScopes = (response.result as FsdbScopeInfo[]) ?? [];
+      this.netlistTop = topScopes.map((scope) =>
+        createScope(scope.name, scope.type, [], scope.netlistId, scope.scopeOffsetIdx, this.uri)
+      );
     });
 
     await vscode.window.withProgress({
@@ -205,14 +214,6 @@ export class FsdbFormatHandler implements WaveformFileParser {
         vscode.window.showErrorMessage("Failed to load FSDB reader, is vaporview.fsdbReaderLibsPath properly set? (" + errorCode + ")");
         break;
       }
-      case 'fsdb-scope-callback': {
-        this.fsdbScopeCallback(message.name, message.type, message.path, message.netlistId, message.scopeOffsetIdx);
-        break;
-      }
-      case 'fsdb-upscope-callback': {
-        this.fsdbUpscopeCallback();
-        break;
-      }
       case 'setMetadata': {
         this.metadata.scopeCount = message.scopecount;
         this.metadata.netlistIdCount = message.varcount;
@@ -237,6 +238,14 @@ export class FsdbFormatHandler implements WaveformFileParser {
       }
       case 'fsdb-array-end-callback': {
         this.fsdbArrayEndCallback(message.size);
+        break;
+      }
+      case 'fsdb-struct-begin-callback': {
+        this.fsdbStructBeginCallback(message.name, message.type, message.path, message.netlistId);
+        break;
+      }
+      case 'fsdb-struct-end-callback': {
+        this.fsdbStructEndCallback();
         break;
       }
     }
@@ -267,6 +276,9 @@ export class FsdbFormatHandler implements WaveformFileParser {
   private async fsdbReadVars(element: NetlistItem | undefined) {
     if (!element) return;
     this.fsdbCurrentScope = element;
+    this.fsdbVarsBuffer = [];
+    this.fsdbChildrenStack = [this.fsdbVarsBuffer];
+    this.fsdbStructNameStack = [];
 
     let scopePath = "";
     if (element.scopePath.length !== 0) { scopePath += element.scopePath.join(".") + "."; }
@@ -277,14 +289,132 @@ export class FsdbFormatHandler implements WaveformFileParser {
       scopePath: scopePath,
       scopeOffsetIdx: element.scopeOffsetIdx
     });
+
+    element.children.push(...this.fsdbVarsBuffer);
+    this.fsdbVarsBuffer = [];
+    this.fsdbChildrenStack = [];
+    this.fsdbStructNameStack = [];
+  }
+
+  private fsdbCurrentChildren(): NetlistItem[] {
+    return this.fsdbChildrenStack[this.fsdbChildrenStack.length - 1];
+  }
+
+  private async fsdbReadChildScopes(element: NetlistItem): Promise<NetlistItem[]> {
+    // VHDL array scopes are synthetic (scopeOffsetIdx === -1) and have no FSDB children.
+    if (element.scopeOffsetIdx < 0) {
+      return [];
+    }
+
+    const scopePath = element.scopePath.concat([element.name]);
+    const result: NetlistItem[] = [];
+    let itemsRemaining = Infinity;
+    let startIndex = 0;
+    let callLimit = 255;
+
+    while (itemsRemaining > 0) {
+      const response = await this.callFsdbWorkerTask({
+        command: 'getScopeChildren',
+        scopeOffsetIdx: element.scopeOffsetIdx,
+        startIndex: startIndex
+      });
+      const childItems = (response.result as FsdbScopeChildrenResult) ?? {
+        scopes: [],
+        totalReturned: 0,
+        remainingItems: 0
+      };
+      itemsRemaining = childItems.remainingItems;
+      startIndex += childItems.totalReturned;
+
+      for (const child of childItems.scopes) {
+        result.push(createScope(child.name, child.type, scopePath, child.netlistId, child.scopeOffsetIdx, this.uri));
+      }
+
+      callLimit--;
+      if (callLimit <= 0) { break; }
+    }
+
+    return result;
+  }
+
+  // Group same-named bit selects under a bus parent (matches surfer/wasm netlist UX).
+  private mergeDuplicateFsdbVars(children: NetlistItem[]): NetlistItem[] {
+    const scopes: NetlistItem[] = [];
+    const varTable: Record<string, NetlistItem[]> = {};
+    const seenSignalIds = new Set<number>();
+
+    for (const child of children) {
+      if (child.contextValue === 'netlistScope') {
+        scopes.push(child);
+        continue;
+      }
+      // Exact duplicates from concurrent getChildren / double readVars.
+      if (seenSignalIds.has(child.signalId)) { continue; }
+      seenSignalIds.add(child.signalId);
+
+      const key = child.name;
+      if (varTable[key] === undefined) {
+        varTable[key] = [child];
+      } else {
+        varTable[key].push(child);
+      }
+    }
+
+    const result: NetlistItem[] = [...scopes];
+    for (const vars of Object.values(varTable)) {
+      if (vars.length === 1) {
+        result.push(vars[0]);
+        continue;
+      }
+
+      const bitList: NetlistItem[] = [];
+      const busList: NetlistItem[] = [];
+      let parent: NetlistItem | undefined;
+      let maxWidth = 0;
+      for (const varItem of vars) {
+        if (varItem.width === 1) { bitList.push(varItem); }
+        else { busList.push(varItem); }
+      }
+      for (const busItem of busList) {
+        if (busItem.width > maxWidth) {
+          maxWidth = busItem.width;
+          parent = busItem;
+        }
+        result.push(busItem);
+      }
+      if (parent !== undefined) {
+        parent.children = bitList;
+        parent.collapsibleState = vscode.TreeItemCollapsibleState.Collapsed;
+      } else {
+        result.push(...bitList);
+      }
+    }
+
+    return result;
+  }
+
+  private async loadScopeChildren(element: NetlistItem): Promise<NetlistItem[]> {
+    // Load child scopes first, then vars (mirrors previous order: scopes then signals).
+    const childScopes = await this.fsdbReadChildScopes(element);
+    element.children = childScopes;
+    await this.fsdbReadVars(element);
+    element.children = this.mergeDuplicateFsdbVars(element.children);
+    element.fsdbVarLoaded = true;
+    return element.children;
   }
 
   async getChildren(element: NetlistItem | undefined): Promise<NetlistItem[]> {
     if (!element) { return this.netlistTop; }
     if (element.fsdbVarLoaded) { return element.children; }
-    await this.fsdbReadVars(element);
-    element.fsdbVarLoaded = true;
-    return element.children;
+
+    const inFlight = this.childrenLoadInFlight.get(element);
+    if (inFlight) { return inFlight; }
+
+    const loadPromise = this.loadScopeChildren(element).finally(() => {
+      this.childrenLoadInFlight.delete(element);
+    });
+    this.childrenLoadInFlight.set(element, loadPromise);
+    return loadPromise;
   }
 
   async getSignalData(signalIdList: SignalId[]): Promise<void> {
@@ -379,10 +509,10 @@ export class FsdbFormatHandler implements WaveformFileParser {
       this.fsdbWorker.disconnect();
       this.fsdbWorker = undefined;
     }
-    this.fsdbTopModuleCount = 0;
     this.fsdbCurrentScope = undefined;
     this.parametersLoaded = false;
     this.netlistTop = [];
+    this.childrenLoadInFlight.clear();
   }
 
   dispose(): void {
@@ -390,45 +520,56 @@ export class FsdbFormatHandler implements WaveformFileParser {
   }
 
   // FSDB callback methods
-  private fsdbScopeCallback(name: string, type: string, path: string, netlistId: number, scopeOffsetIdx: number) {
-    const scopePath = path.split('.');
-    this.netlistTop.push(createScope(name, type, scopePath, netlistId, scopeOffsetIdx, this.uri));
+  private fsdbPathToScopePath(path: string): string[] {
+    return path.length === 0 ? [] : path.split('.');
   }
 
-  private fsdbUpscopeCallback() {
-    const scope = this.netlistTop.pop()!;
-    if (this.netlistTop.length === this.fsdbTopModuleCount) {
-      this.netlistTop.push(scope);
-      this.fsdbTopModuleCount++;
-    } else {
-      this.netlistTop[this.netlistTop.length - 1].children.push(scope);
-    }
+  private fsdbGroupScopePath(path: string): string[] {
+    return this.fsdbPathToScopePath(path).concat(this.fsdbStructNameStack);
   }
 
   private fsdbVarCallback(name: string, type: string, encoding: string, path: string, netlistId: NetlistId, signalId: SignalId, width: number, msb: number, lsb: number) {
     const enumType = "";
     const paramValue = "";
-    const scopePath = path.split('.');
+    const scopePath = this.fsdbGroupScopePath(path);
     const varItem = createVar(name, paramValue, type, encoding, scopePath, netlistId, signalId, width, msb, lsb, enumType, true /*isFsdb*/, this.uri);
-    this.fsdbCurrentScope!.children.push(varItem);
-    //this.delegate.netlistIdTable[varItem.netlistId] = varItem;
+    this.fsdbCurrentChildren().push(varItem);
   }
 
   private fsdbArrayBeginCallback(name: string, path: string, netlistId: number) {
-    const scopePath = path.split('.');
-    this.fsdbCurrentScope!.children.push(createScope(name, "vhdlarray", scopePath, netlistId, -1, this.uri));
+    const scopePath = this.fsdbGroupScopePath(path);
+    const arrayScope = createScope(name, "vhdlarray", scopePath, netlistId, -1, this.uri);
+    this.fsdbCurrentChildren().push(arrayScope);
+    this.fsdbChildrenStack.push(arrayScope.children);
+    this.fsdbStructNameStack.push(name);
   }
 
-  private fsdbArrayEndCallback(size: number) {
-    const arrayElements = [];
-    for (let i = 0; i < size; i++) {
-      const element = this.fsdbCurrentScope!.children.pop()!;
-      arrayElements.push(element);
+  private fsdbArrayEndCallback(_size: number) {
+    this.fsdbChildrenStack.pop();
+    this.fsdbStructNameStack.pop();
+    const parentChildren = this.fsdbCurrentChildren();
+    const arrayScope = parentChildren[parentChildren.length - 1];
+    if (arrayScope) {
+      arrayScope.fsdbVarLoaded = true;
     }
-    const array = this.fsdbCurrentScope!.children.pop()!;
-    array.children.push(...arrayElements.reverse());
-    array.fsdbVarLoaded = true;
-    this.fsdbCurrentScope!.children.unshift(array);
+  }
+
+  private fsdbStructBeginCallback(name: string, type: string, path: string, netlistId: number) {
+    const scopePath = this.fsdbGroupScopePath(path);
+    const structScope = createScope(name, type, scopePath, netlistId, -1, this.uri);
+    this.fsdbCurrentChildren().push(structScope);
+    this.fsdbChildrenStack.push(structScope.children);
+    this.fsdbStructNameStack.push(name);
+  }
+
+  private fsdbStructEndCallback() {
+    this.fsdbChildrenStack.pop();
+    this.fsdbStructNameStack.pop();
+    const parentChildren = this.fsdbCurrentChildren();
+    const structScope = parentChildren[parentChildren.length - 1];
+    if (structScope) {
+      structScope.fsdbVarLoaded = true;
+    }
   }
 
   // TODO: @heyfey - implement netlist search

--- a/src/extension_core/fsdb_handler.ts
+++ b/src/extension_core/fsdb_handler.ts
@@ -91,7 +91,6 @@ export class FsdbFormatHandler implements WaveformFileParser {
   private providerDelegate: VaporviewDocumentDelegate;
   private uri: vscode.Uri;
   private fsdbWorker: ChildProcess | undefined = undefined;
-  private fsdbCurrentScope: NetlistItem | undefined = undefined;
   // Vars collected for the in-flight readVars call (avoids races on children.push).
   private fsdbVarsBuffer: NetlistItem[] = [];
   // Nest STRUCT/RECORD/array children while reading vars for a scope.
@@ -104,8 +103,11 @@ export class FsdbFormatHandler implements WaveformFileParser {
   public netlistSearchable: boolean = false;
   private netlistTop: NetlistItem[] = [];
   private parametersLoaded: boolean = false;
-  // VS Code may call getChildren concurrently while expanding; coalesce loads.
+  // VS Code may call getChildren concurrently while expanding; coalesce loads
+  // per element and serialize them globally, since the readVars callback state
+  // (fsdbVarsBuffer/fsdbChildrenStack) is shared across the whole handler.
   private childrenLoadInFlight = new Map<NetlistItem, Promise<NetlistItem[]>>();
+  private childrenLoadChain: Promise<unknown> = Promise.resolve();
 
   public postMessageToWebview = (_message: Record<string, unknown>) => {};
   public metadata: WaveformDumpMetadata = {
@@ -275,7 +277,6 @@ export class FsdbFormatHandler implements WaveformFileParser {
 
   private async fsdbReadVars(element: NetlistItem | undefined) {
     if (!element) return;
-    this.fsdbCurrentScope = element;
     this.fsdbVarsBuffer = [];
     this.fsdbChildrenStack = [this.fsdbVarsBuffer];
     this.fsdbStructNameStack = [];
@@ -290,7 +291,9 @@ export class FsdbFormatHandler implements WaveformFileParser {
       scopeOffsetIdx: element.scopeOffsetIdx
     });
 
-    element.children.push(...this.fsdbVarsBuffer);
+    // concat instead of push(...spread): spreading very large var lists can
+    // overflow the argument limit on huge scopes.
+    element.children = element.children.concat(this.fsdbVarsBuffer);
     this.fsdbVarsBuffer = [];
     this.fsdbChildrenStack = [];
     this.fsdbStructNameStack = [];
@@ -341,16 +344,18 @@ export class FsdbFormatHandler implements WaveformFileParser {
   private mergeDuplicateFsdbVars(children: NetlistItem[]): NetlistItem[] {
     const scopes: NetlistItem[] = [];
     const varTable: Record<string, NetlistItem[]> = {};
-    const seenSignalIds = new Set<number>();
+    const seenVars = new Set<string>();
 
     for (const child of children) {
       if (child.contextValue === 'netlistScope') {
         scopes.push(child);
         continue;
       }
-      // Exact duplicates from concurrent getChildren / double readVars.
-      if (seenSignalIds.has(child.signalId)) { continue; }
-      seenSignalIds.add(child.signalId);
+      // Drop exact duplicates from a double readVars, but keep aliased vars
+      // (different names sharing a signalId) by keying on label too.
+      const varKey = child.signalId + ':' + child.label;
+      if (seenVars.has(varKey)) { continue; }
+      seenVars.add(varKey);
 
       const key = child.name;
       if (varTable[key] === undefined) {
@@ -385,6 +390,9 @@ export class FsdbFormatHandler implements WaveformFileParser {
       if (parent !== undefined) {
         parent.children = bitList;
         parent.collapsibleState = vscode.TreeItemCollapsibleState.Collapsed;
+        // Mark loaded so expanding the bus doesn't trigger a scope load that
+        // would wipe the nested bits and readVars an invalid scopeOffsetIdx.
+        parent.fsdbVarLoaded = true;
       } else {
         result.push(...bitList);
       }
@@ -410,9 +418,13 @@ export class FsdbFormatHandler implements WaveformFileParser {
     const inFlight = this.childrenLoadInFlight.get(element);
     if (inFlight) { return inFlight; }
 
-    const loadPromise = this.loadScopeChildren(element).finally(() => {
-      this.childrenLoadInFlight.delete(element);
-    });
+    // Chain onto the previous load so only one readVars runs at a time.
+    const loadPromise = this.childrenLoadChain
+      .then(() => this.loadScopeChildren(element))
+      .finally(() => {
+        this.childrenLoadInFlight.delete(element);
+      });
+    this.childrenLoadChain = loadPromise.catch(() => {});
     this.childrenLoadInFlight.set(element, loadPromise);
     return loadPromise;
   }
@@ -509,10 +521,13 @@ export class FsdbFormatHandler implements WaveformFileParser {
       this.fsdbWorker.disconnect();
       this.fsdbWorker = undefined;
     }
-    this.fsdbCurrentScope = undefined;
     this.parametersLoaded = false;
     this.netlistTop = [];
     this.childrenLoadInFlight.clear();
+    this.childrenLoadChain = Promise.resolve();
+    this.fsdbVarsBuffer = [];
+    this.fsdbChildrenStack = [];
+    this.fsdbStructNameStack = [];
   }
 
   dispose(): void {

--- a/src/extension_core/fsdb_types.ts
+++ b/src/extension_core/fsdb_types.ts
@@ -7,10 +7,24 @@ export type FsdbWaveformData = {
   max: number;
 };
 
+export type FsdbScopeInfo = {
+  name: string;
+  type: string;
+  netlistId: number;
+  scopeOffsetIdx: number;
+};
+
+export type FsdbScopeChildrenResult = {
+  scopes: FsdbScopeInfo[];
+  totalReturned: number;
+  remainingItems: number;
+};
+
 // Commands sent from handler → worker
 export type FsdbWorkerCommand =
   | { command: 'openFsdb'; fsdbPath: string }
   | { command: 'readScopes' }
+  | { command: 'getScopeChildren'; scopeOffsetIdx: number; startIndex: number }
   | { command: 'readMetadata' }
   | { command: 'readVars'; scopePath: string; scopeOffsetIdx: number }
   | { command: 'loadSignals'; signalIdList: number[] }

--- a/src/extension_core/fsdb_worker.ts
+++ b/src/extension_core/fsdb_worker.ts
@@ -1,11 +1,25 @@
 import type { NetlistId, SignalId } from '../common/types';
-import type { FsdbWaveformData, FsdbWorkerIpcMessage } from './fsdb_types';
+import type {
+    FsdbScopeChildrenResult,
+    FsdbScopeInfo,
+    FsdbWaveformData,
+    FsdbWorkerIpcMessage,
+} from './fsdb_types';
 
 interface FsdbAddon {
     openFsdb(fsdbPath: string): void;
-    readScopes(scopeCallback: (name: string, type: string, path: string, netlistId: number, scopeOffsetIdx: number) => void, upscopeCallback: () => void): void;
+    readScopes(): FsdbScopeInfo[];
+    getScopeChildren(scopeOffsetIdx: number, startIndex: number): FsdbScopeChildrenResult;
     readMetadata(setMetadataFn: (scopecount: number, varcount: number, timescale: number, timeunit: string) => void, setChunkSizeFn: (chunksize: number, timeend: number) => void): void;
-    readVars(scopePath: string, scopeOffsetIdx: number, varCallback: (...args: Parameters<typeof fsdbVarCallback>) => void, arrayBeginCallback: (name: string, path: string, netlistId: number) => void, arrayEndCallback: (size: number) => void): void;
+    readVars(
+        scopePath: string,
+        scopeOffsetIdx: number,
+        varCallback: (...args: Parameters<typeof fsdbVarCallback>) => void,
+        arrayBeginCallback: (name: string, path: string, netlistId: number) => void,
+        arrayEndCallback: (size: number) => void,
+        structBeginCallback: (name: string, type: string, path: string, netlistId: number) => void,
+        structEndCallback: () => void,
+    ): void;
     loadSignals(signalIdList: number[]): void;
     getValueChanges(signalId: number): FsdbWaveformData;
     getValuesAtTime(signalId: number, time: number): string | string[];
@@ -31,14 +45,25 @@ process.on('message', (message: FsdbWorkerIpcMessage) => {
     process.send!({ id: message.id, result: result });
 });
 
-function handleMessage(message: FsdbWorkerIpcMessage): FsdbWaveformData | string | string[] | undefined {
+function handleMessage(message: FsdbWorkerIpcMessage): FsdbWaveformData | string | string[] | FsdbScopeInfo[] | FsdbScopeChildrenResult | undefined {
     if (!fsdbAddon) { return undefined; }
     switch (message.command) {
         case 'openFsdb': { fsdbAddon.openFsdb(message.fsdbPath); break; }
-        case 'readScopes': { fsdbAddon.readScopes(fsdbScopeCallback, fsdbUpscopeCallback); break; }
+        case 'readScopes': { return fsdbAddon.readScopes(); }
+        case 'getScopeChildren': {
+            return fsdbAddon.getScopeChildren(message.scopeOffsetIdx, message.startIndex);
+        }
         case 'readMetadata': { fsdbAddon.readMetadata(setMetadata, setChunkSize); break; }
         case 'readVars': {
-            fsdbAddon.readVars(message.scopePath, message.scopeOffsetIdx, fsdbVarCallback, fsdbArrayBeginCallback, fsdbArrayEndCallback);
+            fsdbAddon.readVars(
+                message.scopePath,
+                message.scopeOffsetIdx,
+                fsdbVarCallback,
+                fsdbArrayBeginCallback,
+                fsdbArrayEndCallback,
+                fsdbStructBeginCallback,
+                fsdbStructEndCallback,
+            );
             break;
         }
         case 'loadSignals': { fsdbAddon.loadSignals(message.signalIdList); break; }
@@ -48,23 +73,6 @@ function handleMessage(message: FsdbWorkerIpcMessage): FsdbWaveformData | string
         case 'unload': { fsdbAddon.unload(); break; }
     }
     return undefined;
-}
-
-function fsdbScopeCallback(name: string, type: string, path: string, netlistId: number, scopeOffsetIdx: number) {
-    process.send!({
-        command: 'fsdb-scope-callback',
-        name: name,
-        type: type,
-        path: path,
-        netlistId: netlistId,
-        scopeOffsetIdx: scopeOffsetIdx
-    });
-}
-
-function fsdbUpscopeCallback() {
-    process.send!({
-        command: 'fsdb-upscope-callback'
-    });
 }
 
 function setMetadata(scopecount: number, varcount: number, timescale: number, timeunit: string) {
@@ -113,5 +121,21 @@ function fsdbArrayEndCallback(size: number) {
     process.send!({
         command: 'fsdb-array-end-callback',
         size: size,
+    });
+}
+
+function fsdbStructBeginCallback(name: string, type: string, path: string, netlistId: number) {
+    process.send!({
+        command: 'fsdb-struct-begin-callback',
+        name: name,
+        type: type,
+        path: path,
+        netlistId: netlistId
+    });
+}
+
+function fsdbStructEndCallback() {
+    process.send!({
+        command: 'fsdb-struct-end-callback',
     });
 }

--- a/src/extension_core/tree_view.ts
+++ b/src/extension_core/tree_view.ts
@@ -155,12 +155,17 @@ export function createVar(
   const field = bitRangeString(msb, lsb, false);
   let label = name;
 
-  // field is already included in signal name for fsdb
-  if (!isFsdb) label = name + field;
-
-  if (isFsdb) { // remove field from signal name for fsdb to align with wellen
-    const regex  = /\[(\d+:)?(\d+)\]$/;
-    name = name.replace(regex, '');
+  if (isFsdb) {
+    // Prefer FSDB's own [msb:lsb] suffix when present; otherwise add it so
+    // bit-selects with the same base name are distinguishable in the tree.
+    const regex = /\[(\d+:)?(\d+)\]$/;
+    const stripped = name.replace(regex, '');
+    if (stripped === name && field !== '') {
+      label = name + field;
+    }
+    name = stripped;
+  } else {
+    label = name + field;
   }
 
   let variableEncoding = VariableEncoding.none;

--- a/src/fsdb_reader.cpp
+++ b/src/fsdb_reader.cpp
@@ -1,6 +1,6 @@
 #include <napi.h>
 
-#include <sstream>
+#include <cstdint>
 #include <stack>
 #include <string>
 #include <vector>
@@ -22,7 +22,7 @@ const int TRUE = 1;
 const int FALSE = 0;
 #endif
 
-static void __DumpScope(fsdbTreeCBDataScope *scope);
+static void __RecordScope(fsdbTreeCBDataScope *scope);
 static void __DumpVar(fsdbTreeCBDataVar *var);
 static void __DumpArray(fsdbTreeCBDataArrayBegin *array);
 static void __EndArray();
@@ -31,17 +31,54 @@ static bool_T MyTreeCB(fsdbTreeCBType cb_type, void *client_data,
 static void __PrintTimeValChng(ffrVCTrvsHdl vc_trvs_hdl, fsdbTag64 *time,
                                byte_T *vc_ptr, const Napi::CallbackInfo &info,
                                Napi::Array &result, double &min, double &max);
+static const char *ScopeTypeToString(uint8_t type);
+static Napi::Object MakeScopeObject(Napi::Env env, uint32_t scopeIdx);
 
 std::string fsdb_name;
 
 ffrObject *fsdb_obj = nullptr;
 
-// Logical offsets in scope 'Top'
+// Logical offsets for ffrReadVarByLogUOff, indexed by scopeOffsetIdx
 static std::vector<fsdbLUOff> scope_offset;
 
-static std::vector<std::string> scope_path_stack;
+// Compact native hierarchy: built once during readScopes, queried lazily from JS.
+// Avoids materializing millions of NetlistItems / IPC messages in the extension host.
+enum ScopeType : uint8_t {
+  kScopeModule = 0,
+  kScopeTask,
+  kScopeFunction,
+  kScopeBegin,
+  kScopeFork,
+  kScopeUnknown,
+};
+
+struct ScopeNode {
+  std::string name;
+  ScopeType type;
+};
+
+static std::vector<ScopeNode> scope_nodes;
+// CSR adjacency: children of scope i are children_flat[children_begin[i] .. children_begin[i+1])
+static std::vector<uint32_t> children_flat;
+static std::vector<uint32_t> children_begin;
+// Temporary during walk; flattened into CSR at end of readScopes.
+static std::vector<std::vector<uint32_t>> scope_children_build;
+static std::vector<uint32_t> top_scopes;
+static std::vector<uint32_t> scope_index_stack;
+
 static std::string scope_path;
 static std::stack<uint_T> arraysize_stack;
+
+// Max child scopes returned per getScopeChildren call (pagination).
+static const uint32_t kMaxScopesPerPage = 2000;
+
+// Tree-walk mode:
+// - building_scope_index: ffrReadScopeTree() — record hierarchy only (ignore vars)
+// - otherwise: ffrReadVarByLogUOff() — emit this scope's vars/arrays/structs.
+//   Nested module SCOPE depth is skipped; STRUCT/RECORD are emitted so JS can
+//   nest them (otherwise identical leaf names like aw_ready collide).
+static bool building_scope_index = false;
+static int module_depth = 0;
 
 // Not using atomic here. Note that we assume all addon call will be
 // synchronous, put "await" for all addon calls if not sure what you're doing
@@ -49,11 +86,11 @@ unsigned int netlistId = 0;
 Napi::Env env_global = nullptr;
 
 // Object from node.js area
-Napi::Function fsdbScopeCallback;
-Napi::Function fsdbUpscopeCallback;
 Napi::Function fsdbVarCallback;
 Napi::Function fsdbArrayBeginCallback;
 Napi::Function fsdbArrayEndCallback;
+Napi::Function fsdbStructBeginCallback;
+Napi::Function fsdbStructEndCallback;
 
 bool CHECK_LENGTH(const Napi::Env &env, const Napi::CallbackInfo &info,
                   size_t size) {
@@ -132,18 +169,129 @@ void openFsdb(const Napi::CallbackInfo &info) {
   }
 }
 
-void readScopes(const Napi::CallbackInfo &info) {
+static void clearScopeIndex() {
+  scope_offset.clear();
+  scope_nodes.clear();
+  children_flat.clear();
+  children_begin.clear();
+  scope_children_build.clear();
+  top_scopes.clear();
+  scope_index_stack.clear();
+  building_scope_index = false;
+  module_depth = 0;
+}
+
+static void flattenScopeChildren() {
+  children_begin.resize(scope_children_build.size() + 1);
+  size_t total = 0;
+  for (size_t i = 0; i < scope_children_build.size(); i++) {
+    children_begin[i] = static_cast<uint32_t>(total);
+    total += scope_children_build[i].size();
+  }
+  children_begin[scope_children_build.size()] = static_cast<uint32_t>(total);
+
+  children_flat.clear();
+  children_flat.reserve(total);
+  for (auto &kids : scope_children_build) {
+    children_flat.insert(children_flat.end(), kids.begin(), kids.end());
+  }
+  // Free the temporary vector-of-vectors; CSR is the long-lived index.
+  std::vector<std::vector<uint32_t>>().swap(scope_children_build);
+}
+
+// Walk the full FSDB scope tree once, keeping only a compact native index.
+// Top-level scopes are returned; nested scopes are fetched via getScopeChildren.
+Napi::Array readScopes(const Napi::CallbackInfo &info) {
   Napi::Env env = info.Env();
   env_global = env;
-  if (!CHECK_LENGTH(env, info, 2)) return;
-  if (!CHECK_FUNCTION(env, info[0])) return;
-  if (!CHECK_FUNCTION(env, info[1])) return;
 
-  fsdbScopeCallback = info[0].As<Napi::Function>();
-  fsdbUpscopeCallback = info[1].As<Napi::Function>();
+  clearScopeIndex();
+  netlistId = 0;
 
+  building_scope_index = true;
+  module_depth = 0;
   fsdb_obj->ffrSetTreeCBFunc(MyTreeCB, NULL);
   fsdb_obj->ffrReadScopeTree();
+  building_scope_index = false;
+  flattenScopeChildren();
+
+  // Reserve [0, scopeCount) for scope netlistIds; vars allocate after that.
+  netlistId = static_cast<unsigned int>(scope_nodes.size());
+
+  Napi::Array result = Napi::Array::New(env, top_scopes.size());
+  for (uint32_t i = 0; i < top_scopes.size(); i++) {
+    result.Set(i, MakeScopeObject(env, top_scopes[i]));
+  }
+  return result;
+}
+
+Napi::Object getScopeChildren(const Napi::CallbackInfo &info) {
+  Napi::Env env = info.Env();
+  Napi::Object result = Napi::Object::New(env);
+  result.Set("scopes", Napi::Array::New(env, 0));
+  result.Set("totalReturned", Napi::Number::New(env, 0));
+  result.Set("remainingItems", Napi::Number::New(env, 0));
+
+  if (!CHECK_LENGTH(env, info, 2)) return result;
+  if (!CHECK_NUMBER(env, info[0])) return result;
+  if (!CHECK_NUMBER(env, info[1])) return result;
+
+  size_t scopeOffsetIdx =
+      static_cast<size_t>(info[0].As<Napi::Number>().Uint32Value());
+  uint32_t startIndex = info[1].As<Napi::Number>().Uint32Value();
+
+  if (scopeOffsetIdx + 1 >= children_begin.size()) {
+    return result;
+  }
+
+  uint32_t childStart = children_begin[scopeOffsetIdx];
+  uint32_t childEnd = children_begin[scopeOffsetIdx + 1];
+  uint32_t total = childEnd - childStart;
+  if (startIndex >= total) {
+    return result;
+  }
+
+  uint32_t available = total - startIndex;
+  uint32_t toReturn =
+      available > kMaxScopesPerPage ? kMaxScopesPerPage : available;
+
+  Napi::Array scopes = Napi::Array::New(env, toReturn);
+  for (uint32_t i = 0; i < toReturn; i++) {
+    scopes.Set(i, MakeScopeObject(env, children_flat[childStart + startIndex + i]));
+  }
+
+  result.Set("scopes", scopes);
+  result.Set("totalReturned", Napi::Number::New(env, toReturn));
+  result.Set("remainingItems", Napi::Number::New(env, available - toReturn));
+  return result;
+}
+
+static Napi::Object MakeScopeObject(Napi::Env env, uint32_t scopeIdx) {
+  Napi::Object obj = Napi::Object::New(env);
+  const ScopeNode &node = scope_nodes[scopeIdx];
+  obj.Set("name", Napi::String::New(env, node.name));
+  obj.Set("type", Napi::String::New(env, ScopeTypeToString(node.type)));
+  // Use scopeOffsetIdx as the stable netlistId for scopes.
+  obj.Set("netlistId", Napi::Number::New(env, scopeIdx));
+  obj.Set("scopeOffsetIdx", Napi::Number::New(env, scopeIdx));
+  return obj;
+}
+
+static const char *ScopeTypeToString(uint8_t type) {
+  switch (type) {
+    case kScopeModule:
+      return "module";
+    case kScopeTask:
+      return "task";
+    case kScopeFunction:
+      return "function";
+    case kScopeBegin:
+      return "begin";
+    case kScopeFork:
+      return "fork";
+    default:
+      return "unknown_scope_type";
+  }
 }
 
 ulong_T combineTime(uint_T H, uint_T L) {
@@ -208,15 +356,31 @@ void readMetadata(const Napi::CallbackInfo &info) {
   setChunkSize.Call(args2);
 }
 
+static void __DumpStructBegin(const char *name, const char *type) {
+  std::vector<Napi::Value> args;
+  args.push_back(Napi::String::New(env_global, name ? name : ""));
+  args.push_back(Napi::String::New(env_global, type));
+  args.push_back(Napi::String::New(env_global, scope_path));
+  args.push_back(Napi::Number::New(env_global, netlistId));
+  fsdbStructBeginCallback.Call(args);
+  netlistId++;
+}
+
+static void __DumpStructEnd() {
+  fsdbStructEndCallback.Call(std::vector<Napi::Value>());
+}
+
 void readVars(const Napi::CallbackInfo &info) {
   Napi::Env env = info.Env();
   env_global = env;
-  if (!CHECK_LENGTH(env, info, 5)) return;
+  if (!CHECK_LENGTH(env, info, 7)) return;
   if (!CHECK_STRING(env, info[0])) return;
   if (!CHECK_NUMBER(env, info[1])) return;
   if (!CHECK_FUNCTION(env, info[2])) return;
   if (!CHECK_FUNCTION(env, info[3])) return;
   if (!CHECK_FUNCTION(env, info[4])) return;
+  if (!CHECK_FUNCTION(env, info[5])) return;
+  if (!CHECK_FUNCTION(env, info[6])) return;
 
   scope_path = info[0].As<Napi::String>();
   size_t scopeOffsetIdx =
@@ -224,6 +388,19 @@ void readVars(const Napi::CallbackInfo &info) {
   fsdbVarCallback = info[2].As<Napi::Function>();
   fsdbArrayBeginCallback = info[3].As<Napi::Function>();
   fsdbArrayEndCallback = info[4].As<Napi::Function>();
+  fsdbStructBeginCallback = info[5].As<Napi::Function>();
+  fsdbStructEndCallback = info[6].As<Napi::Function>();
+
+  if (scopeOffsetIdx >= scope_offset.size()) {
+    Napi::TypeError::New(env, "scopeOffsetIdx out of range")
+        .ThrowAsJavaScriptException();
+    return;
+  }
+
+  // Do not mutate the scope index while reading vars. Nested module SCOPE
+  // depth is skipped; STRUCT/RECORD are forwarded to JS for nesting.
+  building_scope_index = false;
+  module_depth = 0;
 
   if (FSDB_RC_FAILURE ==
       fsdb_obj->ffrReadVarByLogUOff(&scope_offset[scopeOffsetIdx])) {
@@ -248,6 +425,8 @@ static bool_T MyTreeCB(fsdbTreeCBType cb_type, void *client_data,
   // fsdbTreeCBDataUpscope *pUpscope;
   fsdbTreeCBDataVar *pVar;
   fsdbTreeCBDataArrayBegin *pArray;
+  fsdbTreeCBDataStructBegin *pStruct;
+  fsdbTreeCBDataRecordBegin *pRecord;
 
   switch (cb_type) {
     case FSDB_TREE_CBT_BEGIN_TREE:
@@ -255,26 +434,34 @@ static bool_T MyTreeCB(fsdbTreeCBType cb_type, void *client_data,
       break;
 
     case FSDB_TREE_CBT_SCOPE:
-      // The first time 'Top' is entered, record its logical offset.
-      // Other logical offsets of 'Top' will be known when an
-      // UPSCOPE sets the current traverse point to 'Top'.
       pScope = (fsdbTreeCBDataScope *)tree_cb_data;
-      scope_offset.push_back(pScope->var_start_log_uoff);
-      __DumpScope(pScope);
+      if (building_scope_index) {
+        // Record logical offset and compact hierarchy node; no JS/IPC per scope.
+        scope_offset.push_back(pScope->var_start_log_uoff);
+        __RecordScope(pScope);
+      } else {
+        // Nested module under the scope being read — skip its contents.
+        module_depth++;
+      }
       break;
 
     case FSDB_TREE_CBT_UPSCOPE:
-      // pUpscope = (fsdbTreeCBDataUpscope *)tree_cb_data;
-      // scope_offset.push_back(pUpscope->var_start_log_uoff);
-      // fprintf(stderr, "<Upscope>\n");
-
-      fsdbUpscopeCallback.Call(std::vector<Napi::Value>());
-      scope_path_stack.pop_back();
+      if (building_scope_index) {
+        if (!scope_index_stack.empty()) {
+          scope_index_stack.pop_back();
+        }
+      } else if (module_depth > 0) {
+        module_depth--;
+      }
       break;
 
     case FSDB_TREE_CBT_VAR:
-      pVar = (fsdbTreeCBDataVar *)tree_cb_data;
-      __DumpVar(pVar);
+      // Scope-tree indexing must ignore vars (callbacks are not installed).
+      // Struct fields are emitted; JS nests them under STRUCT/RECORD scopes.
+      if (!building_scope_index && module_depth == 0) {
+        pVar = (fsdbTreeCBDataVar *)tree_cb_data;
+        __DumpVar(pVar);
+      }
       break;
 
     case FSDB_TREE_CBT_END_TREE:
@@ -282,26 +469,42 @@ static bool_T MyTreeCB(fsdbTreeCBType cb_type, void *client_data,
       break;
 
     case FSDB_TREE_CBT_ARRAY_BEGIN:
-      pArray = (fsdbTreeCBDataArrayBegin *)tree_cb_data;
-      __DumpArray(pArray);
+      if (!building_scope_index && module_depth == 0) {
+        pArray = (fsdbTreeCBDataArrayBegin *)tree_cb_data;
+        __DumpArray(pArray);
+      }
       break;
 
     case FSDB_TREE_CBT_ARRAY_END:
-      __EndArray();
+      if (!building_scope_index && module_depth == 0) {
+        __EndArray();
+      }
       break;
 
     case FSDB_TREE_CBT_RECORD_BEGIN:
-      // fprintf(stderr, "<BeginRecord>\n");
+      if (!building_scope_index && module_depth == 0) {
+        pRecord = (fsdbTreeCBDataRecordBegin *)tree_cb_data;
+        __DumpStructBegin(pRecord->name, "vhdlrecord");
+      }
       break;
 
     case FSDB_TREE_CBT_RECORD_END:
-      // fprintf(stderr, "<EndRecord>\n\n");
+      if (!building_scope_index && module_depth == 0) {
+        __DumpStructEnd();
+      }
       break;
 
     case FSDB_TREE_CBT_STRUCT_BEGIN:
+      if (!building_scope_index && module_depth == 0) {
+        pStruct = (fsdbTreeCBDataStructBegin *)tree_cb_data;
+        __DumpStructBegin(pStruct->name, "struct");
+      }
       break;
 
     case FSDB_TREE_CBT_STRUCT_END:
+      if (!building_scope_index && module_depth == 0) {
+        __DumpStructEnd();
+      }
       break;
 
     case FSDB_TREE_CBT_FILE_TYPE:
@@ -326,65 +529,39 @@ static bool_T MyTreeCB(fsdbTreeCBType cb_type, void *client_data,
   return TRUE;
 }
 
-static std::string joinScopePath(std::vector<std::string> &scope_path_stack) {
-  if (scope_path_stack.empty()) {
-    return "";
-  }
-  std::ostringstream oss;
-  oss << scope_path_stack[0];  // Add the first item without a leading
-                               // delimiter
-
-  // Append the rest with a delimiter "."
-  for (size_t i = 1; i < scope_path_stack.size(); i++) {
-    oss << "." << scope_path_stack[i];
-  }
-
-  return oss.str();
-}
-
-static void __DumpScope(fsdbTreeCBDataScope *scope) {
-  str_T type;
-
+static void __RecordScope(fsdbTreeCBDataScope *scope) {
+  ScopeType type;
   switch (scope->type) {
     case FSDB_ST_VCD_MODULE:
-      type = (str_T) "module";
+      type = kScopeModule;
       break;
-
     case FSDB_ST_VCD_TASK:
-      type = (str_T) "task";
+      type = kScopeTask;
       break;
-
     case FSDB_ST_VCD_FUNCTION:
-      type = (str_T) "function";
+      type = kScopeFunction;
       break;
-
     case FSDB_ST_VCD_BEGIN:
-      type = (str_T) "begin";
+      type = kScopeBegin;
       break;
-
     case FSDB_ST_VCD_FORK:
-      type = (str_T) "fork";
+      type = kScopeFork;
       break;
-
     default:
-      type = (str_T) "unknown_scope_type";
+      type = kScopeUnknown;
       break;
   }
 
-  // fprintf(stderr, "<Scope> name:%s  type:%s\n", scope->name, type);
+  uint32_t idx = static_cast<uint32_t>(scope_nodes.size());
+  scope_nodes.push_back(ScopeNode{std::string(scope->name), type});
+  scope_children_build.emplace_back();
 
-  // scope_path_stack.push_back(scope->name);
-  std::string path = joinScopePath(scope_path_stack);
-  scope_path_stack.push_back(scope->name);
-
-  std::vector<Napi::Value> args;
-  args.push_back(Napi::String::New(env_global, scope->name));
-  args.push_back(Napi::String::New(env_global, type));
-  args.push_back(Napi::String::New(env_global, path));
-  args.push_back(Napi::Number::New(env_global, netlistId));
-  args.push_back(Napi::Number::New(env_global, scope_offset.size() - 1));
-  fsdbScopeCallback.Call(args);
-  netlistId++;
+  if (scope_index_stack.empty()) {
+    top_scopes.push_back(idx);
+  } else {
+    scope_children_build[scope_index_stack.back()].push_back(idx);
+  }
+  scope_index_stack.push_back(idx);
 }
 
 static void __DumpVar(fsdbTreeCBDataVar *var) {
@@ -988,8 +1165,7 @@ Napi::Array getValuesAtTime(const Napi::CallbackInfo &info) {
 }
 
 void unload(const Napi::CallbackInfo &info) {
-  scope_offset.clear();
-  scope_path_stack.clear();
+  clearScopeIndex();
   std::stack<uint_T> s;
   arraysize_stack.swap(s);  // clear the stack
   env_global = nullptr;
@@ -1008,6 +1184,8 @@ Napi::Object Init(Napi::Env env, Napi::Object exports) {
               Napi::Function::New(env, readMetadata));
   exports.Set(Napi::String::New(env, "readScopes"),
               Napi::Function::New(env, readScopes));
+  exports.Set(Napi::String::New(env, "getScopeChildren"),
+              Napi::Function::New(env, getScopeChildren));
   exports.Set(Napi::String::New(env, "readVars"),
               Napi::Function::New(env, readVars));
   exports.Set(Napi::String::New(env, "loadSignals"),


### PR DESCRIPTION
## Summary
- Keep a compact native FSDB scope index during `ffrReadScopeTree` instead of eagerly building millions of `NetlistItem`s over IPC (avoids extension-host OOM on large dumps).
- Load child scopes on expand via `getScopeChildren`, then vars via `ffrReadVarByLogUOff` (same on-demand pattern as VCD/FST).
- Emit FSDB `STRUCT`/`RECORD` as nested netlist scopes so leaf names like `aw_ready` are not flattened into duplicates under the parent module.

## Test plan
- [ ] Rebuild FSDB addon (`npm run compile-addon`) with Verdi FSDB reader libs/headers
- [ ] Open a small FSDB and confirm hierarchy expands (modules → children → signals)
- [ ] Open a large multi-million-scope FSDB and confirm “Reading Scopes” completes without JS heap OOM
- [ ] Expand a scope that contains SV structs/AXI interfaces and confirm signals appear under struct folders (no repeated `aw_ready` at the parent level)
- [ ] Add a few signals to the viewer and confirm waveforms still load